### PR TITLE
feat : 룰 기반 미니멀/맥시멀 판별 파이프라인 추가 및 점수화 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ yolov8n.pt
 datasets/
 ClothingParts_v1i_yolov11/
 
+__pycache__/

--- a/scripts/test_maximal.py
+++ b/scripts/test_maximal.py
@@ -1,0 +1,21 @@
+import os, sys
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.append(PROJECT_ROOT)
+
+from src.pipelines.maximal_pipeline import MaximalPipeline
+
+image_path = r"dataset\maximal\0049efd51c5af1d0ef72144a2cf611dd.jpg"
+pipe = MaximalPipeline(threshold=5)
+
+res = pipe.detect_and_analyze(image_path, conf_threshold=0.4, verbose=True)  # 임계값 낮춤
+
+if not res.get("success"):
+    print("Error:", res.get("error"))
+    print("total_detections:", res.get("total_detections"))
+    sys.exit(1)
+
+print("predicted_style:", res["predicted_style"])
+print("maximal_score:", res["maximal_score"])
+print("core_item_count:", res["core_item_count"])
+print("total_detections:", res.get("total_detections"))

--- a/src/analyzers/maximal_analyzer.py
+++ b/src/analyzers/maximal_analyzer.py
@@ -1,0 +1,74 @@
+"""
+Maximal 분석 모듈
+YOLOS 감지 결과를 받아 핵심 아이템 개수 기반으로 미니멀/맥시멀을 판단
+"""
+
+from typing import List, Dict, Any, Tuple
+import math
+
+from ..config.labels import is_core_item, classify_style_by_core_count, compute_maximal_score
+
+
+class MaximalAnalyzer:
+    """Maximal 분석기 (핵심 아이템 카운트 기반)"""
+
+    def __init__(self, threshold: int = 5):
+        self.threshold = int(threshold)
+
+    def analyze_detections(self, detections: List[Dict[str, Any]], verbose: bool = True) -> Dict[str, Any]:
+        """
+        감지 결과를 입력 받아 스타일을 분류
+        Args:
+            detections: YOLOS 감지 결과 리스트 [{class_id,int, class_name,str, confidence,float, bbox,[...]}]
+            verbose: 로깅 여부
+        Returns:
+            {
+              "predicted_style": "minimal"|"maximal",
+              "core_item_count": int,
+              "core_ratio": float,
+              "threshold": int,
+              "per_region": [ {region_id, class_id, class_name, is_core_item, confidence, bbox}, ... ]
+            }
+        """
+        # 1) 중복/쌍 처리: 동일 클래스 다중 박스는 1개로 캡 (간단 캡 방식)
+        #    신발(23) 등 좌우 쌍으로 감지되는 항목이 과대 카운트되는 것을 방지
+        seen_classes = set()
+        dedup_labels = []
+        for det in detections:
+            cid = det.get("class_id")
+            if cid in seen_classes:
+                continue
+            seen_classes.add(cid)
+            dedup_labels.append(cid)
+
+        labels = dedup_labels
+        style, core_count, core_ratio = classify_style_by_core_count(labels, threshold=self.threshold)
+        score = compute_maximal_score(core_count, self.threshold)
+        # 소수점 4자리 절삭
+        factor = 10 ** 4
+        score = math.trunc(score * factor) / float(factor)
+
+        per_region = []
+        for i, det in enumerate(detections):
+            per_region.append({
+                "region_id": i,
+                "class_id": det.get("class_id"),
+                "class_name": det.get("class_name"),
+                "is_core_item": bool(is_core_item(det.get("class_id"))),
+                "confidence": det.get("confidence"),
+                "bbox": det.get("bbox"),
+            })
+
+        if verbose:
+            print(f"🔢 핵심 아이템 개수: {core_count} (threshold={self.threshold}) → style={style}")
+
+        return {
+            "predicted_style": style,
+            "core_item_count": core_count,
+            "core_ratio": core_ratio,
+            "threshold": self.threshold,
+            "maximal_score": score,  # [-1,1]에서 미니멀(-1~0], 맥시멀[0~1]
+            "per_region": per_region,
+        }
+
+

--- a/src/config/labels.py
+++ b/src/config/labels.py
@@ -161,3 +161,48 @@ def get_formality_label(score: int) -> str:
     if score < 0:
         return "Casual"
     return "Neutral"
+
+
+# =========================
+# Minimal / Maximal 판단을 위한 핵심 아이템 정의
+# =========================
+
+# 핵심 아이템: 의상 본체/주요 액세서리. 구조적 요소(27~45)는 제외
+# Fashionpedia 기준으로 0~26 범주를 핵심으로 간주
+CORE_ITEM_IDS = set([i for i in range(0, 27)])
+
+
+def is_core_item(class_id: int) -> bool:
+    """핵심 아이템 여부 반환"""
+    return int(class_id) in CORE_ITEM_IDS
+
+
+def classify_style_by_core_count(label_id_list, threshold: int = 5):
+    """
+    감지된 라벨 ID 리스트를 받아 핵심 아이템 개수로 스타일을 분류
+    Args:
+        label_id_list: 감지된 객체들의 클래스 ID 시퀀스
+        threshold: 맥시멀로 판단할 핵심 아이템 개수 임계값
+    Returns:
+        (predicted_style:str, core_item_count:int, core_ratio:float)
+    """
+    core_count = sum(1 for cid in label_id_list if is_core_item(int(cid)))
+    total = max(1, len(label_id_list))
+    core_ratio = float(core_count) / float(total)
+    style = "maximal" if core_count >= int(threshold) else "minimal"
+    return style, core_count, core_ratio
+
+
+def compute_maximal_score(core_item_count: int, threshold: int) -> float:
+    """
+    스무딩된 최대화 점수 계산 (tanh 기반)
+    - threshold에서 0이 되도록 중심을 맞추고, tau로 기울기를 제어
+    - 극단값 포화를 완화해 점수가 급격히 1/-1로 포화되지 않도록 함
+    """
+    import math
+    t = max(1, int(threshold))
+    # 중심화: (count - threshold). tau는 완만함(스무딩) 제어. threshold의 절반을 기본으로.
+    tau = max(1e-6, t / 2.0)
+    x = (float(core_item_count) - float(t)) / float(tau)
+    score = math.tanh(x)  # [-1, 1]
+    return float(score)

--- a/src/pipelines/maximal_pipeline.py
+++ b/src/pipelines/maximal_pipeline.py
@@ -1,43 +1,79 @@
 """
 Maximal 분석 파이프라인
-YOLO 감지와 분석을 통합하여 maximal 점수를 산출하는 모듈
-
-TODO: 구현 예정
-- maximal 특성 분석 알고리즘 개발
-- maximal 점수 계산 로직 구현
+YOLO 감지와 MaximalAnalyzer를 통합하여 미니멀/맥시멀을 판단하는 모듈
 """
 
 from typing import Dict, Any
 from .base_pipeline import BasePipeline
+from ..detectors.object_detector import ObjectDetector
+from ..analyzers.maximal_analyzer import MaximalAnalyzer
+from ..processors.result_processor import ResultProcessor
 
 
 class MaximalPipeline(BasePipeline):
     """Maximal 분석 파이프라인 (맥시멀/미니멀 분석)"""
-    
-    def __init__(self):
-        """파이프라인 초기화"""
-        # TODO: maximal 관련 분석기들 초기화
-        pass
-    
-    def detect_and_analyze(self, image_path: str, **kwargs) -> Dict[str, Any]:
+
+    def __init__(self, threshold: int = 5):
+        self.detector = ObjectDetector()
+        self.analyzer = MaximalAnalyzer(threshold=threshold)
+        self.processor = ResultProcessor()
+
+    def detect_and_analyze(self, image_path: str, conf_threshold: float = 0.8, verbose: bool = True, **kwargs) -> Dict[str, Any]:
         """
         이미지에서 객체를 감지하고 maximal 분석
-        
+
         Args:
             image_path: 이미지 파일 경로
-            **kwargs: 추가 파라미터
-            
+            conf_threshold: YOLOS 신뢰도 임계값
+            verbose: 로그 출력 여부
+
         Returns:
             maximal 분석 결과 딕셔너리
         """
-        # TODO: maximal 분석 로직 구현
-        return {
-            "error": "Maximal 분석은 아직 구현되지 않았습니다.",
-            "success": False,
-            "pipeline_type": "maximal"
+        # 입력 검증
+        validation = self.processor.validate_inputs(image_path)
+        if validation:
+            return validation
+
+        # YOLO 준비 확인
+        if not self.detector.is_ready():
+            return self.processor.create_error_result("YOLO 분석기가 초기화되지 않았습니다.", image_path)
+
+        if verbose:
+            from os.path import basename
+            print(f"테스트 이미지: {basename(image_path)}")
+            print("\n2. YOLO 객체 감지 중...")
+
+        # 감지
+        detections = self.detector.detect_objects(image_path, conf_threshold=conf_threshold, verbose=verbose)
+        if not detections:
+            return self.processor.create_error_result("감지된 객체가 없습니다.", image_path)
+
+        # 분석
+        if verbose:
+            print("\n3. Maximal 분석 중...")
+        analysis = self.analyzer.analyze_detections(detections, verbose=verbose)
+
+        # 결과 구성
+        result = {
+            "success": True,
+            "pipeline_type": "maximal",
+            "image_path": image_path,
+            "detections": analysis.get("per_region", []),
+            "predicted_style": analysis.get("predicted_style"),
+            "core_item_count": analysis.get("core_item_count", 0),
+            "core_ratio": analysis.get("core_ratio", 0.0),
+            "threshold": analysis.get("threshold"),
+            "maximal_score": analysis.get("maximal_score", 0.0),
+            "total_detections": len(detections),
         }
-    
+        return result
+
     def visualize_results(self, analysis_result: Dict[str, Any]) -> None:
-        """분석 결과 시각화"""
-        # TODO: maximal 시각화 구현
-        print("⚠️ Maximal 시각화는 아직 구현되지 않았습니다.")
+        # 간단 텍스트 출력 (상세 시각화는 image_visualizer 확장 시 연동)
+        if not analysis_result.get("success"):
+            print("시각화할 Maximal 결과가 없습니다.")
+            return
+        style = analysis_result.get("predicted_style")
+        count = analysis_result.get("core_item_count")
+        print(f"Maximal 결과: style={style}, core_items={count}")

--- a/src/pipelines/unified_pipeline.py
+++ b/src/pipelines/unified_pipeline.py
@@ -45,7 +45,7 @@ class UnifiedPipeline(BasePipeline):
         )
         results["colorful"] = colorful_result
         
-        # 2. Maximal 분석 (TODO)
+        # 2. Maximal 분석 (구현 완료)
         if verbose:
             print("🔥 Maximal 분석 중...")
         maximal_result = self.maximal_pipeline.detect_and_analyze(

--- a/src/pipelines/unified_pipeline.py
+++ b/src/pipelines/unified_pipeline.py
@@ -84,7 +84,8 @@ class UnifiedPipeline(BasePipeline):
                 unified_detection = detection.copy()
                 unified_detection["scores"] = {
                     "colorful_score": detection.get("saturation_score", 0.0),
-                    "maximal_score": 0.0,  # TODO: maximal 구현 후 실제 값
+                    # 최대화 점수는 현재 핵심 아이템 여부를 1/0로 단순 부여 (추후 고도화 가능)
+                    "maximal_score": 1.0 if detection.get("is_core_item") else 0.0,
                     "formal_score": None
                 }
                 unified_detections.append(unified_detection)
@@ -103,6 +104,11 @@ class UnifiedPipeline(BasePipeline):
                 else:
                     ud["scores"]["formal_score"] = 0.0
 
+            overall_maximal_score = 0.0
+            if results["maximal"].get("success"):
+                # 이미지 수준 maximal 점수: [-1,1] 범위 점수 사용
+                overall_maximal_score = float(results["maximal"].get("maximal_score", 0.0))
+
             return {
                 "image_path": image_path,
                 "success": True,
@@ -116,7 +122,7 @@ class UnifiedPipeline(BasePipeline):
                 },
                 "overall_scores": {
                     "colorful_score": colorful_result.get("average_score", 0.0),
-                    "maximal_score": 0.0,  # TODO: 구현 후 실제 값
+                    "maximal_score": overall_maximal_score,
                     "formal_score": results["formal"].get("formal_overall_score", 0.0)
                 }
             }


### PR DESCRIPTION
### 작업 내용
- 미니멀 / 멕시멀 파이프라인 구축
### 작업 상세내용
- YOLOS 감지 결과 기반 룰(핵심 아이템 개수)로 미니멀/맥시멀 판별 추가
- 점수 스케일 [-1,1] 적용(tanh 스무딩), 소수점 4자리 절삭
- 동일 클래스 중복 박스 1개로 캡(쌍/중복 완화)
- UnifiedPipeline에 maximal 점수 연동(overall_scores.maximal_score)